### PR TITLE
Update image to 0.23.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/roman901/vtf-rs"
 edition = "2018"
 
 [dependencies]
-image = "0.22.4"
+image = "0.23.14"
 err-derive = "0.2.2"
 parse-display = "0.1.1"
 num_enum = "0.4"

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,7 @@
 use crate::header::VTFHeader;
 use crate::utils::get_offset;
 use crate::Error;
-use image::dxt::{DXTDecoder, DXTVariant};
+use image::dxt::{DxtDecoder, DXTVariant};
 use image::{DynamicImage, ImageBuffer, ImageDecoder, Pixel};
 use num_enum::TryFromPrimitive;
 use parse_display::Display;
@@ -47,7 +47,9 @@ impl<'a> VTFImage<'a> {
     }
 
     fn decode_dxt(&self, bytes: &[u8], variant: DXTVariant) -> Result<Vec<u8>, Error> {
-        Ok(DXTDecoder::new(bytes, self.width as u32, self.height as u32, variant)?.read_image()?)
+        let mut output: Vec<u8> = Vec::new();
+        DxtDecoder::new(bytes, self.width as u32, self.height as u32, variant)?.read_image(&mut output)?;
+        Ok(output.to_vec())
     }
 
     fn image_from_buffer<P, Container, F>(

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -2,7 +2,7 @@ use crate::header::VTFHeader;
 use crate::image::{ImageFormat, VTFImage};
 use crate::resources::{ResourceList, ResourceType};
 use crate::Error;
-use image::dxt::{DXTEncoder, DXTVariant};
+use image::dxt::{DxtEncoder, DXTVariant};
 use image::{DynamicImage, GenericImageView};
 use std::io::Cursor;
 use std::vec::Vec;
@@ -117,8 +117,8 @@ impl<'a> VTF<'a> {
 
         match image_format {
             ImageFormat::Dxt5 => {
-                let image_data = image.to_rgba();
-                let encoder = DXTEncoder::new(&mut data);
+                let image_data = image.to_rgba8();
+                let encoder = DxtEncoder::new(&mut data);
                 encoder.encode(
                     &image_data,
                     header.width as u32,
@@ -127,8 +127,8 @@ impl<'a> VTF<'a> {
                 )?;
             }
             ImageFormat::Dxt1Onebitalpha => {
-                let image_data = image.to_rgba();
-                let encoder = DXTEncoder::new(&mut data);
+                let image_data = image.to_rgba8();
+                let encoder = DxtEncoder::new(&mut data);
                 encoder.encode(
                     &image_data,
                     header.width as u32,
@@ -137,11 +137,11 @@ impl<'a> VTF<'a> {
                 )?;
             }
             ImageFormat::Rgba8888 => {
-                let image_data = image.to_rgba();
+                let image_data = image.to_rgba8();
                 data.extend_from_slice(&image_data);
             }
             ImageFormat::Rgb888 => {
-                let image_data = image.to_rgb();
+                let image_data = image.to_rgb8();
                 data.extend_from_slice(&image_data);
             }
             _ => return Err(Error::UnsupportedEncodeImageFormat(image_format)),


### PR DESCRIPTION
Changes include switching from DXTEncoder to DxtEncoder, and fixing the return of image::decode_dxt() to follow.
Also switched all to_rgb<a>() methods to to_rgb<a>8() methods as the former is deprecated.
