### PR TITLE
Expose missing items from the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-mod header;
-mod image;
-mod resources;
+pub mod header;
+pub mod image;
+pub mod resources;
 mod utils;
-mod vtf;
+pub mod vtf;
 
 pub use crate::image::ImageFormat;
 use crate::vtf::VTF;


### PR DESCRIPTION
Currently several items are not exposed and do not appear in the documentation (e.g. VTF, VTFHeader, VTFImage).

This PR expose them properly making the documentation complete.