### PR TITLE
switch to using texpresso for DXT encoding/decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 image = "0.23.14"
+texpresso = "2.0.1"
 err-derive = "0.2.2"
 parse-display = "0.1.1"
 num_enum = "0.4"

--- a/examples/png.rs
+++ b/examples/png.rs
@@ -25,8 +25,8 @@ fn main() -> Result<(), Error> {
     match image {
         DynamicImage::ImageRgb8(_) => image.save(&args[2])?,
         DynamicImage::ImageRgba8(_) => image.save(&args[2])?,
-        DynamicImage::ImageBgra8(_) => image.to_rgba().save(&args[2])?,
-        _ => image.to_rgb().save(&args[2])?,
+        DynamicImage::ImageBgra8(_) => image.to_rgba8().save(&args[2])?,
+        _ => image.to_rgb8().save(&args[2])?,
     };
     Ok(())
 }

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -30,7 +30,7 @@ impl<'a> VTF<'a> {
 
         let highres_offset = match header
             .resources
-            .get_by_type(ResourceType::VTF_LEGACY_RSRC_LOW_RES_IMAGE)
+            .get_by_type(ResourceType::VTF_LEGACY_RSRC_IMAGE)
         {
             Some(resource) => resource.data,
             None => {

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -2,10 +2,10 @@ use crate::header::VTFHeader;
 use crate::image::{ImageFormat, VTFImage};
 use crate::resources::{ResourceList, ResourceType};
 use crate::Error;
-use image::dxt::{DxtEncoder, DXTVariant};
 use image::{DynamicImage, GenericImageView};
 use std::io::Cursor;
 use std::vec::Vec;
+use texpresso::{Format, Params};
 
 #[derive(Debug)]
 pub struct VTF<'a> {
@@ -115,26 +115,19 @@ impl<'a> VTF<'a> {
 
         data.resize(header_size, 0);
 
+        let width = header.width as usize;
+        let height = header.height as usize;
+
         match image_format {
             ImageFormat::Dxt5 => {
                 let image_data = image.to_rgba8();
-                let encoder = DxtEncoder::new(&mut data);
-                encoder.encode(
-                    &image_data,
-                    header.width as u32,
-                    header.height as u32,
-                    DXTVariant::DXT5,
-                )?;
+                data.resize(header_size + Format::Bc3.compressed_size(width, height), 0);
+                Format::Bc3.compress(image_data.as_raw(), width, height, Params::default(), &mut data[header_size..]);
             }
             ImageFormat::Dxt1Onebitalpha => {
                 let image_data = image.to_rgba8();
-                let encoder = DxtEncoder::new(&mut data);
-                encoder.encode(
-                    &image_data,
-                    header.width as u32,
-                    header.height as u32,
-                    DXTVariant::DXT1,
-                )?;
+                data.resize(header_size + Format::Bc1.compressed_size(width, height), 0);
+                Format::Bc1.compress(image_data.as_raw(), width, height, Params::default(), &mut data[header_size..]);
             }
             ImageFormat::Rgba8888 => {
                 let image_data = image.to_rgba8();


### PR DESCRIPTION
The decoder in `image` is panicing on some vtf files and it seems that they are [planning to remove the implementation](https://github.com/image-rs/image/issues/1623) in the future.