### PR TITLE
Relax VTF::read argument to &[u8]

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -24,7 +24,7 @@ impl<'a> VTFImage<'a> {
         format: ImageFormat,
         width: u16,
         height: u16,
-        bytes: &'a Vec<u8>,
+        bytes: &'a [u8],
         offset: usize,
     ) -> VTFImage<'a> {
         VTFImage {

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -15,7 +15,7 @@ pub struct VTF<'a> {
 }
 
 impl<'a> VTF<'a> {
-    pub fn read(bytes: &'a Vec<u8>) -> Result<VTF<'a>, Error> {
+    pub fn read(bytes: &'a [u8]) -> Result<VTF<'a>, Error> {
         let mut cursor = Cursor::new(bytes);
 
         let header = VTFHeader::read(&mut cursor)?;

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -15,7 +15,7 @@ pub struct VTF<'a> {
 }
 
 impl<'a> VTF<'a> {
-    pub fn read(bytes: &'a Vec<u8>) -> Result<VTF, Error> {
+    pub fn read(bytes: &'a Vec<u8>) -> Result<VTF<'a>, Error> {
         let mut cursor = Cursor::new(bytes);
 
         let header = VTFHeader::read(&mut cursor)?;

--- a/src/vtf.rs
+++ b/src/vtf.rs
@@ -16,7 +16,7 @@ pub struct VTF<'a> {
 
 impl<'a> VTF<'a> {
     pub fn read(bytes: &'a Vec<u8>) -> Result<VTF, Error> {
-        let mut cursor = Cursor::new(&bytes);
+        let mut cursor = Cursor::new(bytes);
 
         let header = VTFHeader::read(&mut cursor)?;
 


### PR DESCRIPTION
Depends on #10

Changes the public interface, albeit in a way where all existing callers will simply coerce &Vec<u8> to &[u8]