### PR TITLE
Prepare 0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtf"
 description = "Valve Texture format library for Rust"
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT"
 authors = ["Roman Shishkin <spark@uwtech.org>", "Robin Appelman <robin@icewind.nl>"]
 repository = "https://github.com/roman901/vtf-rs"
@@ -12,7 +12,7 @@ exclude = ["/tests"]
 [dependencies]
 image = "0.25.2"
 texpresso = "2.0.1"
-err-derive = "0.3.1"
+thiserror = "2.0.11"
 parse-display = "0.10.0"
 num_enum = "0.7.2"
 byteorder = "1.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,26 +7,26 @@ pub mod vtf;
 pub use crate::image::ImageFormat;
 use crate::vtf::VTF;
 use ::image::DynamicImage;
-use err_derive::Error;
 use num_enum::TryFromPrimitiveError;
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error(display = "IO error: {}", _0)]
-    Io(#[error(source)] std::io::Error),
-    #[error(display = "File does not have a valid vtf signature")]
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("File does not have a valid vtf signature")]
     InvalidSignature,
-    #[error(display = "File does not have a valid vtf image format: {}", _0)]
+    #[error("File does not have a valid vtf image format: {0}")]
     InvalidImageFormat(i16),
-    #[error(display = "Error manipulating image data: {}", _0)]
-    Image(#[error(source)] ::image::ImageError),
-    #[error(display = "Decoding {} images is not supported", _0)]
+    #[error("Error manipulating image data: {0}")]
+    Image(#[from] ::image::ImageError),
+    #[error("Decoding {0} images is not supported")]
     UnsupportedImageFormat(ImageFormat),
-    #[error(display = "Decoded image data does not have the expected size")]
+    #[error("Decoded image data does not have the expected size")]
     InvalidImageData,
-    #[error(display = "Image size needs to be a power of 2 and below 2^16")]
+    #[error("Image size needs to be a power of 2 and below 2^16")]
     InvalidImageSize,
-    #[error(display = "Encoding {} images is not supported", _0)]
+    #[error("Encoding {0} images is not supported")]
     UnsupportedEncodeImageFormat(ImageFormat),
 }
 


### PR DESCRIPTION
- replaces `err_derive` with `thiserror` as `err_derive` started throwing warnings
- add ci
- version bumb