### PR TITLE
Turn off all features for image dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,12 @@ rust-version = "1.67.0"
 exclude = ["/tests"]
 
 [dependencies]
-image = "0.25.2"
+image = { version = "0.25.2", default-features = false }
 texpresso = "2.0.1"
 thiserror = "2.0.11"
 parse-display = "0.10.0"
 num_enum = "0.7.2"
 byteorder = "1.5.0"
+
+[dev-dependencies]
+image = { version = "0.25.2", features = ["png"], default-features = false }


### PR DESCRIPTION
This reduces the dependency count from 160 to 57.